### PR TITLE
docs: fix typos and grammar in SDK documentation

### DIFF
--- a/documentation/android_tutorial.md
+++ b/documentation/android_tutorial.md
@@ -162,7 +162,7 @@ LatchClient
   .startProximityUnlock() // Starts Proximity Unlock
 
 LatchClient
-  .stopProximityUnlock()  // Stops Proximity Unlock and dispose the listener
+  .stopProximityUnlock()  // Stops Proximity Unlock and dispose of the listener
 
 LatchClient
   .proximityUnlockListener()  
@@ -173,7 +173,7 @@ LatchClient
   .startProximityUnlock() // Restarts proximity unlock with a new listener
 ```
 
-We also provide a one-shot proximity unlock functions, similar to `unlock()` and terminates after it unlocks the closest lock.
+We also provide one-shot proximity unlock functions, similar to `unlock()`, that terminate after unlocking the closest lock.
 
 ```
 LatchClient

--- a/documentation/ios_tutorial.md
+++ b/documentation/ios_tutorial.md
@@ -16,7 +16,7 @@ This function takes two parameters:
 
 `token` - representing optional String value of the Auth0 token
 
-`allAccesses` - flag that indicate if we should load all accesses (partner and non-partner) of the user. (introduced in the version `1.44.0`)
+`allAccesses` - flag that indicates if we should load all accesses (partner and non-partner) of the user. (introduced in the version `1.44.0`)
 
 Async/Await
 
@@ -24,7 +24,7 @@ Async/Await
 let token: String? = ... // fetched from Auth0
 
 /* 
-Optional flag that indicate if we should load all accesses (partner and non-partner) of the user.
+Optional flag that indicates if we should load all accesses (partner and non-partner) of the user.
  - If not provided, the default value is `false` and will behave as it was previously.
  - Setting this flag to `true` will load all devices that user has access to.
 */
@@ -44,7 +44,7 @@ Completion Block
 let token = ... // fetched from Auth0
 
 /* 
-Optional flag that indicate if we should load all accesses (partner and non-partner) of the user.
+Optional flag that indicates if we should load all accesses (partner and non-partner) of the user.
  - If not provided, the default value is `false` and will behave as it was previously.
  - Setting this flag to `true` will load all devices that user has access to.
 */
@@ -66,7 +66,7 @@ Latch.initialize(withToken: token) { ... }
 ```
 
 ## Doors and Locks
-The list of locks can be retrieved from local cache using `locks()` or fetched from server using fetchLocks()`
+The list of locks can be retrieved from local cache using `locks()` or fetched from the server using `fetchLocks()`
 
 `locks()` returns the cached list of locks retrieved during initialization. This works even if the device is offline.  
 Use `locks()` when you want a quick response or need to support offline access.  
@@ -153,7 +153,7 @@ latch.sync(lockID: lock.id.uuidString) { result in
 
 ## Access Logs
 
-Access Logs are providing access logs information for a given lock.
+Access Logs provide access log information for a given lock.
 
 Async/Await
 

--- a/documentation/partner_app.md
+++ b/documentation/partner_app.md
@@ -75,7 +75,7 @@ All additional SDK functions require that `initialize(...)` has been invoked wit
 | ----------------------------- | ----------- |
 | `LatchError.invalidToken`     | The supplied authorization token is invalid and should be refreshed. |
 | `LatchError.permissionDenied` | The current user hasn't granted the app access to use the Latch SDK. |
-| `Error`                       | An unexpected error occured |
+| `Error`                       | An unexpected error occurred |
 
 ## Doors and Locks
 
@@ -100,7 +100,7 @@ Retrieve all locks accessible to the current user. This list can be used to buil
 
 | Code    | Description |
 | ------- | ----------- |
-| `Error` | An unexpected error occured |
+| `Error` | An unexpected error occurred |
 
 ## Unlock
 
@@ -133,7 +133,7 @@ Either a success or failure.
 | `LatchError.concurrentUnlockInProgress` | Only one unlock operation is allowed at a time. |
 | `LatchError.lockNotFound`               | Failed to find a lock with a unique identifier matching the given lock ID. |
 | `LatchError.timeout`                    | Unlock failed to complete in a reasonable amount of time. |
-| `Error`                                 | An unexpected error occured | 
+| `Error`                                 | An unexpected error occurred | 
 
 
 

--- a/documentation/user_management.md
+++ b/documentation/user_management.md
@@ -19,7 +19,7 @@ Once a user is invited to Latch, a confirmation notification will be delivered t
 
 Having a Latch Account/Password, enables the user to utilize the Latch app and participate in other Partner Apps that are part of the Latch ecosystem. 
 
-> Anytime a user is invited to Latch either directly or through a Partner, a confirmation email is sent to the user. User’s can take the optional step of finalizing the Latch account by creating a password enabling them to utilize the Latch App.
+> Anytime a user is invited to Latch either directly or through a Partner, a confirmation email is sent to the user. Users can take the optional step of finalizing the Latch account by creating a password enabling them to utilize the Latch App.
 
 Creating a Latch account password and subsequently utilizing the Latch App is a purely optional step by the user and is not a requirement to utilize the Partner App.  
 


### PR DESCRIPTION
## Summary

Fix 7 issues across 4 documentation files:

- `documentation/android_tutorial.md`: Fix subject-verb agreement in proximity unlock description; add missing preposition "of" after "dispose"
- `documentation/ios_tutorial.md`: Fix subject-verb agreement ("flag that indicates") in 3 locations; fix verb tense in Access Logs description; add missing article and backtick in fetchLocks() reference
- `documentation/partner_app.md`: Fix misspelling "occured" → "occurred" in 3 error table entries
- `documentation/user_management.md`: Remove incorrect apostrophe in plural "Users"

No functional changes — documentation only.